### PR TITLE
Issue 9: allowing pythonanywhere domain/host

### DIFF
--- a/data_models/assignments/django_tutorial/django_tutorial/settings.py
+++ b/data_models/assignments/django_tutorial/django_tutorial/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = '5t2$q7o71=(n5h8_$$%!c!p-4-%qz!k7d-*)uvfh^ss*u=0+rd'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['ivanleoncz.pythonanywhere.com', ]
 
 
 # Application definition


### PR DESCRIPTION
- Without this configuration, Django will not allow requests with a
unauthorized host header, like the one provided by PythonAnywhere.